### PR TITLE
17 musings needs og info

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,6 +38,17 @@ export const metadata: Metadata = {
       },
     ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [
+      {
+        url: '/a-okay-monkey-1.png',
+        width: 800,
+        height: 800,
+        alt: 'ꓘO-∀ Monkey',
+      },
+    ],
+  },
   icons: {
     icon: [
       { url: '/favicon.ico' },

--- a/src/app/projects/ProjectsList.tsx
+++ b/src/app/projects/ProjectsList.tsx
@@ -1,0 +1,158 @@
+'use client'
+import { useQuery } from 'convex/react'
+import { api } from '@/convex/_generated/api'
+import { Link2Icon } from '@radix-ui/react-icons'
+import { useState, useEffect, useMemo } from 'react'
+import Image from 'next/image'
+import { showToast } from '@/utils/toast'
+
+export default function ProjectsList() {
+  // Memoize the projects array
+  const projectsQuery = useQuery(api.projects.getAllProjects)
+  const projects = useMemo(() => projectsQuery || [], [projectsQuery])
+
+  // Sort projects by date using useMemo
+  const sortedProjects = useMemo(
+    () =>
+      [...projects].sort(
+        (a, b) =>
+          new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+      ),
+    [projects]
+  )
+
+  const [imageError, setImageError] = useState<Record<string, boolean>>({})
+
+  const validateImageUrl = (url: string) => {
+    try {
+      // Check if the URL is already properly formatted
+      if (
+        url.startsWith(
+          'https://aok-projects-images.s3.us-east-2.amazonaws.com/'
+        )
+      ) {
+        return url
+      }
+      // If it's a relative path, construct the full URL
+      if (url.startsWith('/')) {
+        return `https://aok-projects-images.s3.us-east-2.amazonaws.com${url}`
+      }
+      // Otherwise, try to construct a valid URL
+      new URL(url)
+      return url
+    } catch {
+      console.error('Invalid URL:', url)
+      return '/fallback-project-image.jpg'
+    }
+  }
+
+  // For the Image onError handler
+  const handleImageError = (projectId: string) => {
+    console.error('Image load error for project:', projectId)
+    setImageError((prev) => ({
+      ...prev,
+      [projectId]: true,
+    }))
+  }
+
+  // Add scroll handling effect
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.location.hash) {
+        const hash = window.location.hash.substring(1)
+        const element = document.getElementById(hash)
+        if (element) {
+          element.scrollIntoView({
+            behavior: 'smooth',
+            block: 'start',
+          })
+        }
+      }
+    }
+
+    handleScroll()
+    window.addEventListener('hashchange', handleScroll)
+    return () => window.removeEventListener('hashchange', handleScroll)
+  }, [])
+
+  return (
+    <div className="container mx-auto px-8 py-8 max-w-6xl">
+      <div className="grid grid-cols-12 gap-6">
+        <div className="hidden md:block col-span-2" />
+        <div className="col-span-12 md:col-span-8">
+          <div className="grid grid-cols-1 gap-6">
+            {sortedProjects.map((project) => (
+              <div
+                key={project._id}
+                id={project.slug}
+                className="bg-white dark:bg-white rounded-lg shadow-md overflow-hidden scroll-mt-8"
+              >
+                <div className="relative h-48">
+                  {imageError[project._id] ? (
+                    <div className="w-full h-full flex items-center justify-center bg-gray-100 dark:bg-gray-800">
+                      <span className="text-gray-400">Image not available</span>
+                    </div>
+                  ) : (
+                    <Image
+                      src={validateImageUrl(project.imageUrl)}
+                      alt={project.title}
+                      fill
+                      className="object-cover"
+                      onError={() => handleImageError(project._id)}
+                      priority={sortedProjects.indexOf(project) === 0}
+                      sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                    />
+                  )}
+                </div>
+                <div className="p-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <h2 className="text-xl font-bold">{project.title}</h2>
+                    <button
+                      onClick={() => {
+                        const url = `${window.location.origin}${window.location.pathname}#${project.slug}`
+                        navigator.clipboard.writeText(url)
+                        window.history.pushState({}, '', url)
+                        showToast('Link copied to clipboard!', 3000)
+                      }}
+                      className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+                      aria-label="Copy link to project"
+                    >
+                      <Link2Icon className="w-4 h-4" />
+                    </button>
+                  </div>
+                  <p className="text-sm text-gray-500 dark:text-gray-500 mb-2">
+                    {new Date(project.publishedAt).toLocaleDateString()}
+                  </p>
+                  <p className="text-gray-600 dark:text-gray-600 mb-3">
+                    {project.description}
+                  </p>
+                  <div
+                    className="prose dark:prose-invert max-w-none mb-4"
+                    dangerouslySetInnerHTML={{ __html: project.content }}
+                  />
+                  <ul className="list-disc list-inside text-gray-600 dark:text-gray-600 grid grid-cols-1 mb-4">
+                    {project.tools.map((tool, index) => (
+                      <li key={index}>{tool}</li>
+                    ))}
+                  </ul>
+                  {project.projectUrl && (
+                    <a
+                      href={project.projectUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-block text-blue-500 hover:text-blue-600 transition-colors"
+                    >
+                      {project.projectUrlText || 'View Project'}
+                      <span className="ml-1">→</span>
+                    </a>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="col-span-2" />
+      </div>
+    </div>
+  )
+}

--- a/src/app/projects/[slug]/ProjectDetails.tsx
+++ b/src/app/projects/[slug]/ProjectDetails.tsx
@@ -1,0 +1,79 @@
+'use client'
+import { useQuery } from 'convex/react'
+import { api } from '@/convex/_generated/api'
+import Image from 'next/image'
+import { useState, useEffect } from 'react'
+
+export default function ProjectDetails({ slug }: { slug: string }) {
+  const project = useQuery(api.projects.getProjectBySlug, { slug })
+  const [currentImageIndex, setCurrentImageIndex] = useState(0)
+
+  useEffect(() => {
+    if (window.location.hash) {
+      const id = window.location.hash.substring(1) // Remove the # symbol
+      const element = document.getElementById(id)
+      if (element) {
+        // Add a small delay to ensure the page is fully rendered
+        setTimeout(() => {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        }, 100)
+      }
+    }
+  }, [])
+
+  if (!project) return <div>Loading...</div>
+
+  return (
+    <div className="container mx-auto px-8 py-8 max-w-6xl scroll-smooth">
+      <h1 className="text-3xl font-bold mb-6">{project.title}</h1>
+
+      {/* Image Carousel */}
+      <div className="relative h-96 mb-8">
+        <Image
+          src={project.images[currentImageIndex]}
+          alt={`${project.title} - Image ${currentImageIndex + 1}`}
+          fill
+          className="object-cover rounded-lg"
+        />
+        <div className="absolute bottom-4 right-4 space-x-2">
+          {project.images.map((_, index) => (
+            <button
+              key={index}
+              onClick={() => setCurrentImageIndex(index)}
+              className={`w-3 h-3 rounded-full ${
+                index === currentImageIndex ? 'bg-white' : 'bg-white/50'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Markdown Content */}
+      {renderContent(project.content)}
+    </div>
+  )
+}
+
+// Helper function
+const renderContent = (content: string) => {
+  // If content is HTML, parse it properly
+  if (content.includes('<p>') || content.includes('</p>')) {
+    return (
+      <div
+        className="prose dark:prose-invert max-w-none"
+        dangerouslySetInnerHTML={{ __html: content }}
+      />
+    )
+  }
+
+  // Fallback for plain text/markdown
+  return (
+    <div className="prose dark:prose-invert max-w-none">
+      {content.split('\n').map((paragraph, idx) => (
+        <p key={idx} className="mb-4">
+          {paragraph}
+        </p>
+      ))}
+    </div>
+  )
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,79 +1,37 @@
-'use client'
-import { useQuery } from 'convex/react'
-import { api } from '@/convex/_generated/api'
-import Image from 'next/image'
-import { useState, useEffect } from 'react'
+import { Metadata } from 'next'
+import ProjectDetails from './ProjectDetails'
 
-export default function ProjectPage({ params }: { params: { slug: string } }) {
-  const project = useQuery(api.projects.getProjectBySlug, { slug: params.slug })
-  const [currentImageIndex, setCurrentImageIndex] = useState(0)
-
-  useEffect(() => {
-    if (window.location.hash) {
-      const id = window.location.hash.substring(1) // Remove the # symbol
-      const element = document.getElementById(id)
-      if (element) {
-        // Add a small delay to ensure the page is fully rendered
-        setTimeout(() => {
-          element.scrollIntoView({ behavior: 'smooth', block: 'center' })
-        }, 100)
-      }
-    }
-  }, [])
-
-  if (!project) return <div>Loading...</div>
-
-  return (
-    <div className="container mx-auto px-8 py-8 max-w-6xl scroll-smooth">
-      <h1 className="text-3xl font-bold mb-6">{project.title}</h1>
-
-      {/* Image Carousel */}
-      <div className="relative h-96 mb-8">
-        <Image
-          src={project.images[currentImageIndex]}
-          alt={`${project.title} - Image ${currentImageIndex + 1}`}
-          fill
-          className="object-cover rounded-lg"
-        />
-        <div className="absolute bottom-4 right-4 space-x-2">
-          {project.images.map((_, index) => (
-            <button
-              key={index}
-              onClick={() => setCurrentImageIndex(index)}
-              className={`w-3 h-3 rounded-full ${
-                index === currentImageIndex ? 'bg-white' : 'bg-white/50'
-              }`}
-            />
-          ))}
-        </div>
-      </div>
-
-      {/* Markdown Content */}
-      {renderContent(project.content)}
-    </div>
-  )
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string }
+}): Promise<Metadata> {
+  return {
+    title: `Project: ${params.slug}`,
+    openGraph: {
+      images: [
+        {
+          url: '/a-okay-monkey-1.png',
+          width: 800,
+          height: 800,
+          alt: 'ꓘO-∀ Monkey',
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      images: [
+        {
+          url: '/a-okay-monkey-1.png',
+          width: 800,
+          height: 800,
+          alt: 'ꓘO-∀ Monkey',
+        },
+      ],
+    },
+  }
 }
 
-// Add this helper function
-const renderContent = (content: string) => {
-  // If content is HTML, parse it properly
-  if (content.includes('<p>') || content.includes('</p>')) {
-    return (
-      <div
-        className="prose dark:prose-invert max-w-none"
-        dangerouslySetInnerHTML={{ __html: content }}
-      />
-    )
-  }
-
-  // Fallback for plain text/markdown
-  return (
-    <div className="prose dark:prose-invert max-w-none">
-      {content.split('\n').map((paragraph, idx) => (
-        <p key={idx} className="mb-4">
-          {paragraph}
-        </p>
-      ))}
-    </div>
-  )
+export default function ProjectPage({ params }: { params: { slug: string } }) {
+  return <ProjectDetails slug={params.slug} />
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,160 +1,32 @@
-'use client'
-import { useQuery } from 'convex/react'
-import { api } from '@/convex/_generated/api'
-import { Link2Icon } from '@radix-ui/react-icons'
-import { useState, useEffect, useMemo } from 'react'
-import Image from 'next/image'
-import { showToast } from '@/utils/toast'
+import { Metadata } from 'next'
+import ProjectsList from './ProjectsList'
 
-export const dynamic = 'force-dynamic'
+export const metadata: Metadata = {
+  title: 'Projects',
+  description: 'Check out my latest projects and experiments',
+  openGraph: {
+    images: [
+      {
+        url: '/a-okay-monkey-1.png',
+        width: 800,
+        height: 800,
+        alt: 'ꓘO-∀ Monkey',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [
+      {
+        url: '/a-okay-monkey-1.png',
+        width: 800,
+        height: 800,
+        alt: 'ꓘO-∀ Monkey',
+      },
+    ],
+  },
+}
 
-export default function Projects() {
-  // Memoize the projects array
-  const projectsQuery = useQuery(api.projects.getAllProjects)
-  const projects = useMemo(() => projectsQuery || [], [projectsQuery])
-
-  // Sort projects by date using useMemo
-  const sortedProjects = useMemo(
-    () =>
-      [...projects].sort(
-        (a, b) =>
-          new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
-      ),
-    [projects]
-  )
-
-  const [imageError, setImageError] = useState<Record<string, boolean>>({})
-
-  const validateImageUrl = (url: string) => {
-    try {
-      // Check if the URL is already properly formatted
-      if (
-        url.startsWith(
-          'https://aok-projects-images.s3.us-east-2.amazonaws.com/'
-        )
-      ) {
-        return url
-      }
-      // If it's a relative path, construct the full URL
-      if (url.startsWith('/')) {
-        return `https://aok-projects-images.s3.us-east-2.amazonaws.com${url}`
-      }
-      // Otherwise, try to construct a valid URL
-      new URL(url)
-      return url
-    } catch {
-      console.error('Invalid URL:', url)
-      return '/fallback-project-image.jpg'
-    }
-  }
-
-  // For the Image onError handler
-  const handleImageError = (projectId: string) => {
-    console.error('Image load error for project:', projectId)
-    setImageError((prev) => ({
-      ...prev,
-      [projectId]: true,
-    }))
-  }
-
-  // Add scroll handling effect
-  useEffect(() => {
-    const handleScroll = () => {
-      if (window.location.hash) {
-        const hash = window.location.hash.substring(1)
-        const element = document.getElementById(hash)
-        if (element) {
-          element.scrollIntoView({
-            behavior: 'smooth',
-            block: 'start',
-          })
-        }
-      }
-    }
-
-    handleScroll()
-    window.addEventListener('hashchange', handleScroll)
-    return () => window.removeEventListener('hashchange', handleScroll)
-  }, [])
-
-  return (
-    <div className="container mx-auto px-8 py-8 max-w-6xl">
-      <div className="grid grid-cols-12 gap-6">
-        <div className="hidden md:block col-span-2" />
-        <div className="col-span-12 md:col-span-8">
-          <div className="grid grid-cols-1 gap-6">
-            {sortedProjects.map((project) => (
-              <div
-                key={project._id}
-                id={project.slug}
-                className="bg-white dark:bg-white rounded-lg shadow-md overflow-hidden scroll-mt-8"
-              >
-                <div className="relative h-48">
-                  {imageError[project._id] ? (
-                    <div className="w-full h-full flex items-center justify-center bg-gray-100 dark:bg-gray-800">
-                      <span className="text-gray-400">Image not available</span>
-                    </div>
-                  ) : (
-                    <Image
-                      src={validateImageUrl(project.imageUrl)}
-                      alt={project.title}
-                      fill
-                      className="object-cover"
-                      onError={() => handleImageError(project._id)}
-                      priority={sortedProjects.indexOf(project) === 0}
-                      sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                    />
-                  )}
-                </div>
-                <div className="p-4">
-                  <div className="flex items-center gap-2 mb-2">
-                    <h2 className="text-xl font-bold">{project.title}</h2>
-                    <button
-                      onClick={() => {
-                        const url = `${window.location.origin}${window.location.pathname}#${project.slug}`
-                        navigator.clipboard.writeText(url)
-                        window.history.pushState({}, '', url)
-                        showToast('Link copied to clipboard!', 3000)
-                      }}
-                      className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-                      aria-label="Copy link to project"
-                    >
-                      <Link2Icon className="w-4 h-4" />
-                    </button>
-                  </div>
-                  <p className="text-sm text-gray-500 dark:text-gray-500 mb-2">
-                    {new Date(project.publishedAt).toLocaleDateString()}
-                  </p>
-                  <p className="text-gray-600 dark:text-gray-600 mb-3">
-                    {project.description}
-                  </p>
-                  <div
-                    className="prose dark:prose-invert max-w-none mb-4"
-                    dangerouslySetInnerHTML={{ __html: project.content }}
-                  />
-                  <ul className="list-disc list-inside text-gray-600 dark:text-gray-600 grid grid-cols-1 mb-4">
-                    {project.tools.map((tool, index) => (
-                      <li key={index}>{tool}</li>
-                    ))}
-                  </ul>
-                  {project.projectUrl && (
-                    <a
-                      href={project.projectUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-block text-blue-500 hover:text-blue-600 transition-colors"
-                    >
-                      {project.projectUrlText || 'View Project'}
-                      <span className="ml-1">→</span>
-                    </a>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-        <div className="col-span-2" />
-      </div>
-    </div>
-  )
+export default function ProjectsPage() {
+  return <ProjectsList />
 }


### PR DESCRIPTION
og/image stuff, and refactoring projects page into client and server components

=====

refactor(projects): separate client and server components for metadata

BREAKING CHANGE: Projects page architecture has been restructured to properly
support OpenGraph/Twitter Card metadata generation.

- Split [slug]/page.tsx into server/client components
- Created new ProjectDetails.tsx client component
- Moved interactive logic (carousel, scroll) to client component
- Ensured metadata generation happens server-side
- Fixed social media preview images

This change resolves the Next.js error regarding 'use client' directive
conflicts with metadata generation, while maintaining all existing
functionality. The separation follows Next.js best practices for
handling server-side metadata with client-side interactivity.

Technical notes:
- ProjectDetails.tsx handles all client-side state and effects
- page.tsx focuses solely on server-side concerns (metadata, layout)
- No changes to underlying Convex data fetching