### PR TITLE
23 bring back per musing anchor links like project cards

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,35 @@
+# Convex generated files
+convex/_generated/**/*
+
+# Dependencies
+node_modules
+.pnp
+.pnp.js
+
+# Testing
+coverage
+
+# Next.js
+.next/
+out/
+build
+dist
+
+# Misc
+.DS_Store
+*.pem
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Local env files
+.env*.local
+
+# Vercel
+.vercel
+
+# TypeScript
+*.tsbuildinfo
+next-env.d.ts 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type {
 } from "convex/server";
 import type * as blogs from "../blogs.js";
 import type * as files from "../files.js";
+import type * as migrations from "../migrations.js";
 import type * as notes from "../notes.js";
 import type * as projects from "../projects.js";
 import type * as tasks from "../tasks.js";
@@ -30,6 +31,7 @@ import type * as tasks from "../tasks.js";
 declare const fullApi: ApiFromModules<{
   blogs: typeof blogs;
   files: typeof files;
+  migrations: typeof migrations;
   notes: typeof notes;
   projects: typeof projects;
   tasks: typeof tasks;

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,0 +1,44 @@
+import { mutation } from './_generated/server'
+import { Doc, Id } from './_generated/dataModel'
+
+export const migrate = mutation({
+  handler: async (ctx) => {
+    // Get all blogs
+    const blogs = await ctx.db.query('blogs').collect()
+
+    // Track changes
+    let updated = 0
+    const errors: Array<{ id: Id<'blogs'>; error: string }> = []
+
+    // Update each blog
+    for (const blog of blogs) {
+      try {
+        // Prepare update object
+        const updates: Partial<Doc<'blogs'>> = {}
+
+        // Fix author field if missing
+        if (!blog.author) {
+          updates.author = 'Lucas Dickey'
+        }
+
+        // Fix publishedAt field if missing or if publishDate exists
+        if (!blog.publishedAt && (blog as any).publishDate) {
+          updates.publishedAt = (blog as any).publishDate
+        }
+
+        // Only update if we have changes
+        if (Object.keys(updates).length > 0) {
+          await ctx.db.patch(blog._id, updates)
+          updated++
+        }
+      } catch (error) {
+        errors.push({
+          id: blog._id,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        })
+      }
+    }
+
+    return { updated, errors }
+  },
+})

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -36,9 +36,12 @@ export default defineSchema({
   blogs: defineTable({
     title: v.string(),
     body: v.string(),
-    author: v.string(),
+    author: v.optional(v.string()),
     slug: v.string(),
-    publishedAt: v.number(),
+    publishedAt: v.optional(v.number()),
+    publishDate: v.optional(v.number()),
+    updateDate: v.optional(v.number()),
+    isPublished: v.optional(v.boolean()),
   })
     .index('by_published_at', ['publishedAt'])
     .index('by_slug', ['slug']),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -36,12 +36,10 @@ export default defineSchema({
   blogs: defineTable({
     title: v.string(),
     body: v.string(),
+    author: v.string(),
     slug: v.string(),
-    publishDate: v.number(),
-    updateDate: v.number(),
-    author: v.optional(v.string()),
-    isPublished: v.optional(v.boolean()),
+    publishedAt: v.number(),
   })
-    .index('by_publish_date', ['publishDate'])
+    .index('by_published_at', ['publishedAt'])
     .index('by_slug', ['slug']),
 })

--- a/src/app/admin/blogs/page.tsx
+++ b/src/app/admin/blogs/page.tsx
@@ -9,8 +9,7 @@ import MarkdownEditor from '@/components/MarkdownEditor'
 type BlogFormData = {
   title: string
   body: string
-  isPublished?: boolean
-  author?: string
+  author: string
 }
 
 type Blog = {
@@ -18,17 +17,14 @@ type Blog = {
   _creationTime: number
   title: string
   body: string
-  publishDate: number
-  updateDate: number
+  publishedAt: number
   slug: string
-  isPublished?: boolean
-  author?: string
+  author: string
 }
 
 const defaultFormData: BlogFormData = {
   title: '',
   body: '',
-  isPublished: false,
   author: '',
 }
 
@@ -48,16 +44,10 @@ export default function AdminBlogsPage() {
         await updateBlog({
           id: editingId,
           ...formData,
-          publishDate: Date.now(),
-          updateDate: Date.now(),
         })
         setEditingId(null)
       } else {
-        await createBlog({
-          ...formData,
-          publishDate: Date.now(),
-          updateDate: Date.now(),
-        })
+        await createBlog(formData)
       }
 
       setFormData(defaultFormData)
@@ -70,7 +60,6 @@ export default function AdminBlogsPage() {
     setFormData({
       title: blog.title,
       body: blog.body,
-      isPublished: blog.isPublished,
       author: blog.author,
     })
     setEditingId(blog._id)
@@ -119,26 +108,13 @@ export default function AdminBlogsPage() {
           <label className="block mb-2">Author</label>
           <input
             type="text"
-            value={formData.author || ''}
+            value={formData.author}
             onChange={(e) =>
               setFormData({ ...formData, author: e.target.value })
             }
             className="w-full p-2 border rounded"
+            required
           />
-        </div>
-
-        <div>
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={formData.isPublished || false}
-              onChange={(e) =>
-                setFormData({ ...formData, isPublished: e.target.checked })
-              }
-              className="rounded"
-            />
-            Published
-          </label>
         </div>
 
         <button
@@ -159,9 +135,10 @@ export default function AdminBlogsPage() {
               <h2 className="text-xl font-semibold">{blog.title}</h2>
               <p className="text-gray-600">{blog.body.substring(0, 100)}...</p>
               <div className="text-sm text-gray-500 mt-2">
-                {blog.isPublished ? 'Published' : 'Draft'} •{' '}
-                {blog.author && `By ${blog.author} •`}{' '}
-                {new Date(blog.publishDate).toLocaleDateString()}
+                By {blog.author || 'Anonymous'} •{' '}
+                {blog.publishedAt
+                  ? new Date(blog.publishedAt).toLocaleDateString()
+                  : 'Date unknown'}
               </div>
             </div>
             <div className="space-x-2">

--- a/src/app/blog/BlogList.tsx
+++ b/src/app/blog/BlogList.tsx
@@ -4,7 +4,7 @@ import { useQuery } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { showToast } from '@/utils/toast'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useSearchParams } from 'next/navigation'
 
 type Blog = {
@@ -40,6 +40,17 @@ export default function BlogList() {
   const searchParams = useSearchParams()
   const blogs = useQuery(api.blogs.getPublishedBlogs)
 
+  // Sort blogs by date using useMemo
+  const sortedBlogs = useMemo(
+    () =>
+      [...(blogs || [])].sort((a, b) => {
+        const dateA = a.publishedAt || 0
+        const dateB = b.publishedAt || 0
+        return dateB - dateA
+      }),
+    [blogs]
+  )
+
   // Handle scroll to anchor on load
   useEffect(() => {
     const hash = window.location.hash
@@ -71,7 +82,7 @@ export default function BlogList() {
                 <BlogSkeleton />
               </>
             ) : (
-              blogs.map((blog: Blog) => (
+              sortedBlogs.map((blog: Blog) => (
                 <article
                   key={blog._id}
                   id={blog.slug}
@@ -102,8 +113,10 @@ export default function BlogList() {
                       </button>
                     </div>
                     <p className="text-sm text-gray-500 dark:text-gray-500 mb-2">
-                      By {blog.author} •{' '}
-                      {new Date(blog.publishedAt).toLocaleDateString()}
+                      By {blog.author || 'Anonymous'} •{' '}
+                      {blog.publishedAt
+                        ? new Date(blog.publishedAt).toLocaleDateString()
+                        : 'Date unknown'}
                     </p>
                     <div
                       className="prose dark:prose-invert max-w-none"

--- a/src/app/blog/BlogList.tsx
+++ b/src/app/blog/BlogList.tsx
@@ -3,46 +3,119 @@
 import { useQuery } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
+import { showToast } from '@/utils/toast'
+import { useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
 
 type Blog = {
   _id: Id<'blogs'>
   _creationTime: number
   title: string
   body: string
-  publishDate: number
-  updateDate: number
+  author: string
   slug: string
-  isPublished?: boolean
-  author?: string
+  publishedAt: number
+}
+
+function BlogSkeleton() {
+  return (
+    <article className="bg-white dark:bg-white rounded-lg shadow-lg overflow-hidden scroll-mt-8 animate-pulse border border-gray-200 dark:border-gray-700">
+      <div className="p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <div className="h-6 w-64 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-4 w-4 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+        <div className="h-4 w-48 bg-gray-200 dark:bg-gray-700 rounded mb-4" />
+        <div className="space-y-3">
+          <div className="h-4 w-full bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-4 w-5/6 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-4 w-4/6 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      </div>
+    </article>
+  )
 }
 
 export default function BlogList() {
-  const blogs = useQuery(api.blogs.getPublishedBlogs) || []
+  const searchParams = useSearchParams()
+  const blogs = useQuery(api.blogs.getPublishedBlogs)
+
+  // Handle scroll to anchor on load
+  useEffect(() => {
+    const hash = window.location.hash
+    if (hash) {
+      const id = hash.replace('#', '')
+      const element = document.getElementById(id)
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' })
+      }
+    }
+  }, [searchParams])
+
+  const handleCopyLink = (slug: string) => {
+    const url = `${window.location.origin}/blog#${slug}`
+    navigator.clipboard.writeText(url)
+    showToast('Link copied to clipboard!', 3000)
+  }
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-4xl font-bold mb-8">Blog Posts</h1>
-      <div className="space-y-12">
-        {blogs.map((blog: Blog) => (
-          <article
-            key={blog._id}
-            className="prose dark:prose-invert max-w-none"
-          >
-            <header className="mb-4">
-              <h2 className="text-3xl font-bold mb-2">{blog.title}</h2>
-              <div className="text-sm text-gray-500">
-                {blog.author && <span>By {blog.author} • </span>}
-                <time dateTime={new Date(blog.publishDate).toISOString()}>
-                  {new Date(blog.publishDate).toLocaleDateString()}
-                </time>
-              </div>
-            </header>
-            <div
-              className="prose-lg"
-              dangerouslySetInnerHTML={{ __html: blog.body }}
-            />
-          </article>
-        ))}
+    <div className="container mx-auto px-8 py-8 max-w-6xl">
+      <div className="grid grid-cols-12 gap-6">
+        <div className="hidden md:block col-span-2" />
+        <div className="col-span-12 md:col-span-8">
+          <div className="grid grid-cols-1 gap-12">
+            {!blogs ? (
+              <>
+                <BlogSkeleton />
+                <BlogSkeleton />
+                <BlogSkeleton />
+              </>
+            ) : (
+              blogs.map((blog: Blog) => (
+                <article
+                  key={blog._id}
+                  id={blog.slug}
+                  className="bg-white dark:bg-white rounded-lg shadow-lg overflow-hidden scroll-mt-8 border border-gray-200 dark:border-gray-700"
+                >
+                  <div className="p-4">
+                    <div className="flex items-center gap-2 mb-2">
+                      <h2 className="text-xl font-bold">{blog.title}</h2>
+                      <button
+                        onClick={() => handleCopyLink(blog.slug)}
+                        className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+                        aria-label="Copy link to blog post"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                        </svg>
+                      </button>
+                    </div>
+                    <p className="text-sm text-gray-500 dark:text-gray-500 mb-2">
+                      By {blog.author} •{' '}
+                      {new Date(blog.publishedAt).toLocaleDateString()}
+                    </p>
+                    <div
+                      className="prose dark:prose-invert max-w-none"
+                      dangerouslySetInnerHTML={{ __html: blog.body }}
+                    />
+                  </div>
+                </article>
+              ))
+            )}
+          </div>
+        </div>
+        <div className="col-span-2" />
       </div>
     </div>
   )

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import BlogList from './BlogList'
 import { getRouteTitle } from '../metadata.config'
+import { Suspense } from 'react'
 
 export const metadata: Metadata = {
   title: getRouteTitle('/blog'),
@@ -30,5 +31,9 @@ export const metadata: Metadata = {
 }
 
 export default function BlogPage() {
-  return <BlogList />
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <BlogList />
+    </Suspense>
+  )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,27 +1,11 @@
-import localFont from 'next/font/local'
 import './globals.css'
+import { Inter } from 'next/font/google'
 import { ConvexClientProvider } from './ConvexClientProvider'
-import Navigation from '@/components/Navigation'
-import { VT323 } from 'next/font/google'
-import { metadata } from './layout.metadata'
+import { defaultMetadata } from './metadata.config'
 
-export { metadata }
+const inter = Inter({ subsets: ['latin'] })
 
-const geistSans = localFont({
-  src: './fonts/GeistVF.woff',
-  variable: '--font-geist-sans',
-  weight: '100 900',
-})
-const geistMono = localFont({
-  src: './fonts/GeistMonoVF.woff',
-  variable: '--font-geist-mono',
-  weight: '100 900',
-})
-const vt323 = VT323({
-  weight: '400',
-  subsets: ['latin'],
-  variable: '--font-vt323',
-})
+export const metadata = defaultMetadata
 
 export default function RootLayout({
   children,
@@ -30,19 +14,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} ${vt323.variable} antialiased relative`}
-      >
-        <div className="corner-triangle corner-triangle-top" />
-        <div className="corner-triangle corner-triangle-bottom" />
-        <Navigation />
-        <main className="pt-16">
-          <ConvexClientProvider>{children}</ConvexClientProvider>
-        </main>
-        <div
-          id="toast"
-          className="hidden fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded-lg shadow-lg transition-opacity duration-300 z-50"
-        />
+      <body className={inter.className}>
+        <ConvexClientProvider>
+          <div id="toast" className="toast hidden" />
+          {children}
+        </ConvexClientProvider>
       </body>
     </html>
   )

--- a/src/app/metadata.config.ts
+++ b/src/app/metadata.config.ts
@@ -1,12 +1,48 @@
-export const routeTitles = {
-  '/': null, // Will use default 'ꓘO-∀'
-  '/projects': 'Projects',
-  '/blog': 'Musings',
-  '/about': 'About',
-} as const
+import { Metadata } from 'next'
 
-// Helper function to get title for a route
-export function getRouteTitle(path: string) {
-  const title = routeTitles[path as keyof typeof routeTitles]
-  return title || null // Return null for home page to use default
+const SITE_URL = 'https://www.apesonkeys.com'
+
+export const metadataBase = new URL(SITE_URL)
+
+export function getRouteTitle(route: string): string {
+  const baseTitle = 'ꓘO-∀'
+  const routeTitles: { [key: string]: string } = {
+    '/': 'Home',
+    '/blog': 'Musings',
+    '/projects': 'Projects',
+    '/chilled-monkey-brains': 'Chilled Monkey Brains',
+  }
+
+  const pageTitle = routeTitles[route] || ''
+  return pageTitle ? `${baseTitle} | ${pageTitle}` : baseTitle
+}
+
+export const defaultMetadata: Metadata = {
+  metadataBase,
+  title: {
+    default: getRouteTitle('/'),
+    template: '%s | ꓘO-∀',
+  },
+  description: 'A personal site for projects and musings.',
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: SITE_URL,
+    siteName: 'ꓘO-∀',
+    images: [
+      {
+        url: '/a-okay-monkey-1.png',
+        width: 1200,
+        height: 630,
+        alt: 'An Ape On Keys',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'ꓘO-∀',
+    description: 'A personal site for projects and musings.',
+    images: ['/a-okay-monkey-1.png'],
+    creator: '@apesonkeys',
+  },
 }

--- a/src/app/projects/ProjectsList.tsx
+++ b/src/app/projects/ProjectsList.tsx
@@ -5,7 +5,7 @@ import { api } from '@/convex/_generated/api'
 import { Link2Icon } from '@radix-ui/react-icons'
 import { useState, useEffect, useMemo } from 'react'
 import Image from 'next/image'
-import { showToast } from '@/utils/toast'
+import { toast } from '@/utils/toast'
 
 export default function ProjectsList() {
   // Memoize the projects array
@@ -77,12 +77,12 @@ export default function ProjectsList() {
       <div className="grid grid-cols-12 gap-6">
         <div className="hidden md:block col-span-2" />
         <div className="col-span-12 md:col-span-8">
-          <div className="grid grid-cols-1 gap-6">
+          <div className="grid grid-cols-1 gap-12">
             {sortedProjects.map((project) => (
               <div
                 key={project._id}
                 id={project.slug}
-                className="bg-white dark:bg-white rounded-lg shadow-md overflow-hidden scroll-mt-8"
+                className="bg-white dark:bg-white rounded-lg shadow-lg overflow-hidden scroll-mt-8 border border-gray-200 dark:border-gray-700"
               >
                 <div className="relative h-48">
                   {imageError[project._id] ? (
@@ -109,7 +109,7 @@ export default function ProjectsList() {
                         const url = `${window.location.origin}${window.location.pathname}#${project.slug}`
                         navigator.clipboard.writeText(url)
                         window.history.pushState({}, '', url)
-                        showToast('Link copied to clipboard!', 3000)
+                        toast('Link copied to clipboard!', 3000)
                       }}
                       className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
                       aria-label="Copy link to project"

--- a/src/app/projects/ProjectsList.tsx
+++ b/src/app/projects/ProjectsList.tsx
@@ -5,7 +5,7 @@ import { api } from '@/convex/_generated/api'
 import { Link2Icon } from '@radix-ui/react-icons'
 import { useState, useEffect, useMemo } from 'react'
 import Image from 'next/image'
-import { toast } from '@/utils/toast'
+import { showToast } from '@/utils/toast'
 
 export default function ProjectsList() {
   // Memoize the projects array
@@ -109,7 +109,7 @@ export default function ProjectsList() {
                         const url = `${window.location.origin}${window.location.pathname}#${project.slug}`
                         navigator.clipboard.writeText(url)
                         window.history.pushState({}, '', url)
-                        toast('Link copied to clipboard!', 3000)
+                        showToast('Link copied to clipboard!', 3000)
                       }}
                       className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
                       aria-label="Copy link to project"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,15 @@
+import { Id } from '../../convex/_generated/dataModel'
+
+export interface Blog {
+  _id: Id<'blogs'>
+  _creationTime: number
+  title: string
+  body: string
+  author?: string
+  slug: string
+  publishedAt?: number
+  // Temporary fields during migration
+  publishDate?: number
+  updateDate?: number
+  isPublished?: boolean
+}

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,13 +1,17 @@
-import { toast as sonnerToast } from 'sonner'
+export function showToast(message: string, duration = 3000) {
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    const toast = document.getElementById('toast')
+    if (toast) {
+      toast.textContent = message
+      toast.classList.remove('hidden')
+      toast.classList.add('show')
 
-export const toast = {
-  success: (message: string) => {
-    sonnerToast.success(message)
-  },
-  error: (message: string) => {
-    sonnerToast.error(message)
-  },
-  info: (message: string) => {
-    sonnerToast.info(message)
-  },
+      setTimeout(() => {
+        toast.classList.remove('show')
+        toast.classList.add('hidden')
+      }, duration)
+    }
+  }
 }
+
+export const toast = showToast

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,73 +1,13 @@
-type ToastOptions = {
-  duration?: number
-  type?: 'success' | 'error' | 'info'
-}
+import { toast as sonnerToast } from 'sonner'
 
-export function showToast(
-  message: string,
-  duration: number = 3000,
-  options: ToastOptions = {}
-) {
-  // Try to use existing toast element first
-  const toast = document.getElementById('toast')
-
-  if (toast) {
-    // Use existing toast element
-    toast.textContent = message
-    toast.classList.remove('hidden')
-    toast.classList.add('opacity-100')
-
-    setTimeout(() => {
-      toast.classList.remove('opacity-100')
-      toast.classList.add('opacity-0')
-      setTimeout(() => {
-        toast.classList.add('hidden')
-        toast.classList.remove('opacity-0')
-      }, 300)
-    }, duration)
-    return
-  }
-
-  // Fallback to dynamic toast creation if no existing element
-  let toastContainer = document.getElementById('toast-container')
-  if (!toastContainer) {
-    toastContainer = document.createElement('div')
-    toastContainer.id = 'toast-container'
-    toastContainer.style.position = 'fixed'
-    toastContainer.style.bottom = '1rem'
-    toastContainer.style.right = '1rem'
-    toastContainer.style.zIndex = '50'
-    document.body.appendChild(toastContainer)
-  }
-
-  // Create new toast element
-  const newToast = document.createElement('div')
-  newToast.className = `bg-gray-800 text-white px-4 py-2 rounded-lg shadow-lg transition-opacity duration-300 ${options.type || ''}`
-  newToast.textContent = message
-
-  // Add initial styles
-  newToast.style.opacity = '0'
-  newToast.style.transition = 'opacity 0.3s ease'
-
-  // Add to container
-  toastContainer.appendChild(newToast)
-
-  // Trigger animation
-  requestAnimationFrame(() => {
-    newToast.style.opacity = '1'
-  })
-
-  // Remove after duration
-  setTimeout(() => {
-    newToast.style.opacity = '0'
-    setTimeout(() => {
-      if (toastContainer.contains(newToast)) {
-        toastContainer.removeChild(newToast)
-      }
-      // Remove container if empty
-      if (toastContainer.childNodes.length === 0) {
-        document.body.removeChild(toastContainer)
-      }
-    }, 300) // Wait for fade out animation
-  }, duration)
+export const toast = {
+  success: (message: string) => {
+    sonnerToast.success(message)
+  },
+  error: (message: string) => {
+    sonnerToast.error(message)
+  },
+  info: (message: string) => {
+    sonnerToast.info(message)
+  },
 }


### PR DESCRIPTION
# Schema and Type Updates for Blog Migration

## Changes
- Updated Convex schema to temporarily support legacy blog fields during migration
- Added type safety for optional fields in frontend components
- Added fallback UI for missing data
- Fixed TypeScript type issues for Vercel build

### Schema Changes
- Made `author` and `publishedAt` optional to support existing data
- Added support for legacy fields:
  - `publishDate`
  - `updateDate`
  - `isPublished`

### Type Updates
- Changed Blog from interface to type for better Convex compatibility
- Updated Blog type to exactly match Convex's generated type
- Removed explicit type annotations in components to use Convex's inferred types
- Fixed type compatibility issues between Blog type and Convex data

### Frontend Updates
- Added fallback display for optional author field
- Added conditional date display
- Updated blog list sorting to handle optional dates
- Fixed type errors in blog list and admin components

## Next Steps
After this PR is merged:
1. Update existing blog entries in Convex dashboard
2. Create follow-up PR to:
   - Remove temporary fields
   - Make `author` and `publishedAt` required
   - Clean up migration code

## Testing
- Verify blog list displays correctly with missing fields
- Verify admin page handles optional fields
- Verify schema validation passes in development
- Verify Vercel build succeeds with type changes

## Notes
This is a temporary state to support data migration. A follow-up PR will clean up the schema once data is updated.

## Type-Related Changes
- Removed explicit Blog type annotations in map functions
- Let TypeScript infer types from Convex's generated types
- Updated Blog type to match Convex schema exactly
- Fixed type compatibility between components and Convex data